### PR TITLE
feat: Add author create

### DIFF
--- a/src/routes/authors.js
+++ b/src/routes/authors.js
@@ -33,9 +33,9 @@ router.post('authors.create', '/', async (ctx) => {
   try {
     await author.save({ fields: ['lastName', 'firstName', 'birthDate'] });
     ctx.redirect(ctx.router.url('authors.list'));
-  } catch (validationError) {
+  } catch (e) {
     await ctx.render('authors/new', {
-      errors: validationError.errors,
+      error: e,
       submitAuthorPath: ctx.router.url('authors.create'),
     });
   }

--- a/src/routes/authors.js
+++ b/src/routes/authors.js
@@ -17,9 +17,28 @@ router.get('authors.list', '/', async (ctx) => {
   });
 });
 
+router.get('authors.new', '/new', async (ctx) => {
+  await ctx.render('authors/new', {
+    submitAuthorPath: ctx.router.url('authors.create'),
+  });
+});
+
 router.get('authors.show', '/:id', async (ctx) => {
   const { author } = ctx.state;
   await ctx.render('authors/show', { author, notice: ctx.flashMessage.notice });
+});
+
+router.post('authors.create', '/', async (ctx) => {
+  const author = ctx.orm.author.build(ctx.request.body);
+  try {
+    await author.save({ fields: ['lastName', 'firstName', 'birthDate'] });
+    ctx.redirect(ctx.router.url('authors.list'));
+  } catch (validationError) {
+    await ctx.render('authors/new', {
+      errors: validationError.errors,
+      submitAuthorPath: ctx.router.url('authors.create'),
+    });
+  }
 });
 
 module.exports = router;

--- a/src/routes/authors.js
+++ b/src/routes/authors.js
@@ -13,6 +13,7 @@ router.get('authors.list', '/', async (ctx) => {
   await ctx.render('authors/index', {
     authorsList,
     authorPath: (author) => ctx.router.url('authors.show', { id: author.id }),
+    newAuthorPath: ctx.router.url('authors.new'),
     notice: ctx.flashMessage.notice,
   });
 });

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,7 +4,7 @@ const pkg = require('../../package.json');
 const router = new KoaRouter();
 
 router.get('/', async (ctx) => {
-  await ctx.render('index', { appVersion: pkg.version });
+  await ctx.render('index', { appVersion: pkg.version, authorsPath: ctx.router.url('authors.list') });
 });
 
 module.exports = router;

--- a/src/views/authors/index.html.ejs
+++ b/src/views/authors/index.html.ejs
@@ -22,3 +22,6 @@ Authors!
       <% }) %>
     </tbody>
 </table>
+<p>
+  <a href="<%=newAuthorPath%>">Crear nuevo autor</a>
+</p>

--- a/src/views/authors/new.html.ejs
+++ b/src/views/authors/new.html.ejs
@@ -1,0 +1,32 @@
+
+<!-- <%- include('_form') %> -->
+
+<div>
+    <% if (errors) { %>
+        <div class="errors">
+          You need to fix the following errors:
+          <ul>
+            <% errors.forEach(error => { %>
+              <li><%= error.message %></li>
+            <% }); %>
+          </ul>
+        </div>
+      <% } %>
+    <form action="<%= submitAuthorPath %>" method="post">
+      <div>
+        <label for="firstName">Nombre</label>
+        <input type="text" name="firstName" value="Benjamín" />
+      </div>
+      <div>
+        <label for="lastName">Apellido</label>
+        <input type="text" name="lastName" />
+      </div>
+      <div>
+        <label for="birthDate">Fecha de nacimiento</label>
+        <input type="date" name="birthDate" />
+      </div>
+      <div>
+        <input type="submit" name="create" value="Crear" />
+      </div>
+    </form>
+</div>

--- a/src/views/authors/new.html.ejs
+++ b/src/views/authors/new.html.ejs
@@ -1,15 +1,10 @@
 
-<!-- <%- include('_form') %> -->
+<!-- <%- //include('_form') %> -->
 
 <div>
-    <% if (errors) { %>
+    <% if (locals.error) { %>
         <div class="errors">
-          You need to fix the following errors:
-          <ul>
-            <% errors.forEach(error => { %>
-              <li><%= error.message %></li>
-            <% }); %>
-          </ul>
+          You need to fix the following error: <%= error %>
         </div>
       <% } %>
     <form action="<%= submitAuthorPath %>" method="post">

--- a/src/views/index.html.ejs
+++ b/src/views/index.html.ejs
@@ -3,4 +3,6 @@
   App web version
   <%= appVersion %>
 </p>
+<div>Esta es una aplicaición con código de ejemplo para el uso del template, que no considera estilos. <a href="<%=authorsPath%>">Ver autores</a></div>
+<br>
 <div id="react-app">Here a React app will be rendered</div>


### PR DESCRIPTION
En esta PR se agrega la operación _Create_ para los _author_ de la aplicación. Esto se hace mediante un endpoint get que renderea un formulario, y otro endpoint de tipo post que se encarga de instanciar un modelo respectivo y luego persistirlo en la base de datos.

Agregué un commit arreglando el manejo de error en la creación del autor para que sea más general y considere, por ejemplo, el error de formato que se levanta al ingresar una fecha vacía. Notar que un apellido vacío no levanta validationError porque no es `null`, sino que es un string vacío (`''`). 

Por fines demostrativos se maneja error genérico, aunque en una app completa se deben manejar por tipo, y agregar las validaciones correspondientes (como largo mínimo para apellido)