### PR TITLE
feat: Add authentication protection to books creation

### DIFF
--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,0 +1,9 @@
+function checkAuth(ctx, next) {
+  const { currentUser } = ctx.state;
+  if (!currentUser) ctx.throw(401);
+  return next();
+}
+
+module.exports = {
+  checkAuth,
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,23 +10,37 @@ const session = require('./routes/session');
 const router = new KoaRouter();
 
 router.use(async (ctx, next) => {
-    if (ctx.session.currentUserId){
-      ctx.state.currentUser = await ctx.orm.user.findByPk(ctx.session.currentUserId);
+  try {
+    await next();
+  } catch (err) {
+    switch (err.status) {
+      case 401:
+        ctx.app.emit('error', err, ctx);
+        ctx.redirect(ctx.router.url('session.new'));
+        break;
+      default:
+        throw err;
     }
-    return next();
-  });
-  
+  }
+});
+
 router.use(async (ctx, next) => {
-    Object.assign(ctx.state, {
-      paths: {
-        destroySession: ctx.router.url('session.destroy'),
-        newSession: ctx.router.url('session.new'),
-  
-      },
-    });
-    return next();
+  if (ctx.session.currentUserId) {
+    ctx.state.currentUser = await ctx.orm.user.findByPk(ctx.session.currentUserId);
+  }
+  return next();
+});
+
+router.use(async (ctx, next) => {
+  Object.assign(ctx.state, {
+    paths: {
+      destroySession: ctx.router.url('session.destroy'),
+      newSession: ctx.router.url('session.new'),
+
+    },
   });
-  
+  return next();
+});
 
 router.use('/', index.routes());
 router.use('/hello', hello.routes());
@@ -34,6 +48,5 @@ router.use('/authors', authors.routes());
 router.use('/books', books.routes());
 router.use('/authors/:authorId/books', booksForAuthors.routes());
 router.use('/session', session.routes());
-
 
 module.exports = router;

--- a/src/routes.js
+++ b/src/routes.js
@@ -36,7 +36,6 @@ router.use(async (ctx, next) => {
     paths: {
       destroySession: ctx.router.url('session.destroy'),
       newSession: ctx.router.url('session.new'),
-
     },
   });
   return next();

--- a/src/routes/books.js
+++ b/src/routes/books.js
@@ -1,6 +1,9 @@
 const KoaRouter = require('koa-router');
+const { checkAuth } = require('../middlewares/auth');
 
 const router = new KoaRouter();
+
+router.use(checkAuth);
 
 router.get('books.new', '/new', async (ctx) => {
   const book = ctx.orm.book.build();

--- a/src/routes/booksForAuthors.js
+++ b/src/routes/booksForAuthors.js
@@ -1,6 +1,9 @@
 const KoaRouter = require('koa-router');
+const { checkAuth } = require('../middlewares/auth');
 
 const router = new KoaRouter();
+
+router.use(checkAuth);
 
 async function getAuthor(ctx, next) {
   ctx.state.author = await ctx.orm.author.findByPk(ctx.params.authorId);

--- a/src/views/authors/show.html.ejs
+++ b/src/views/authors/show.html.ejs
@@ -9,5 +9,7 @@
             <li><%= book.title %></li>
         <% }) %>
     </ul>
-    <a href="<%= newBookPath %>">Agregar libro</a>
+    <% if (locals.currentUser) { %>
+        <a href="<%= newBookPath %>">Agregar libro</a>
+    <% } %>
 <% } %>

--- a/src/views/index.html.ejs
+++ b/src/views/index.html.ejs
@@ -4,6 +4,8 @@
   <%= appVersion %>
 </p>
 <div>Esta es una aplicaición con código de ejemplo para el uso del template, que no considera estilos. <a href="<%=authorsPath%>">Ver autores</a></div>
-<a href="<%= newBookPath %>">Agregar libro</a>
+<% if (locals.currentUser) { %>
+  <a href="<%= newBookPath %>">Agregar libro</a>
+<% } %>
 <br>
 <div id="react-app">Here a React app will be rendered</div>


### PR DESCRIPTION
En esta PR se protegen las rutas de creación de libros de forma que solo pueden ser accedidas por un usuario autenticado. Esto permite ejemplificar la protección de rutas con _middlewares_.

Para lograr lo descrito, se creó un _middleware_ (en un nuevo directorio para _middlewares_) que revisa si hay un `currentUser` guardado en el `ctx.state`. Con él se protegen todas las rutas de creación de libros (formularios y _create_'s). En caso de un intento de acceder a una ruta no autorizada, se levanta el `401`, que es manejado con un middleware para redirigir al formulario de _login_.

Adicionalmente, se condiciona el _rendereo_ de los enlaces a formularios de creación de libros a que haya un usuario autenticado.