### PR TITLE
fix(seeds): update books seeds authorId from queries

### DIFF
--- a/src/seeds/20210420000337-add-books.js
+++ b/src/seeds/20210420000337-add-books.js
@@ -1,3 +1,5 @@
+const { QueryTypes } = require('sequelize');
+
 module.exports = {
   up: async (queryInterface) => {
     const booksArray = [];
@@ -9,11 +11,14 @@ module.exports = {
 
     async function findAuthorIdByLastName(lastName) {
       const authors = await queryInterface.sequelize.query(
-        'SELECT "id" FROM "authors" '
-        + `WHERE "authors"."lastName" = '${lastName}'`,
+        'SELECT "id" FROM "authors" WHERE "authors"."lastName" = ?',
+        {
+          replacements: [lastName],
+          type: QueryTypes.SELECT,
+        },
       );
 
-      const [authorId] = authors[0].map(({ id }) => id);
+      const [authorId] = authors.map(({ id }) => id);
       return authorId;
     }
 

--- a/src/seeds/20210420000337-add-books.js
+++ b/src/seeds/20210420000337-add-books.js
@@ -2,37 +2,57 @@ module.exports = {
   up: async (queryInterface) => {
     const booksArray = [];
 
-    booksArray.push({
-      title: 'Harry Potter y la piedra filosofal',
-      publication: 1997,
-      authorId: 2, // Fix this according to your db
+    const commonData = {
       createdAt: new Date(),
       updatedAt: new Date(),
-      description: 'Harry Potter se ha quedado huérfano y vive en casa de sus abominables tíos y el insoportable primo Dudley. Harry se siente muy triste y solo, hasta que un buen día recibe una carta que cambiará su vida para siempre. En ella le comunican que ha sido aceptado como alumno en el Colegio Hogwarts de Magia.',
-      pages: 800,
-    });
+    };
 
-    booksArray.push({
-      title: 'Harry Potter y la camara secreta',
-      publication: 1998,
-      authorId: 2, // Fix this according to your db
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      description: 'La trama sigue el segundo año de Harry Potter en el Colegio Hogwarts de Magia y Hechicería, durante el cual una serie de mensajes en las paredes de los pasillos de la escuela advierten que la Cámara de los Secretos ha sido abierta y que el "heredero de Slytherin" matará a todos los alumnos que no provengan de familias con sangre mágica.',
-      pages: 940,
-    });
+    async function findAuthorIdByLastName(lastName) {
+      const authors = await queryInterface.sequelize.query(
+        'SELECT "id" FROM "authors" '
+        + `WHERE "authors"."lastName" = '${lastName}'`,
+      );
 
-    booksArray.push({
-      title: 'Los juegos del hambre',
-      publication: 2008,
-      authorId: 1, // Fix this according to your db
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      description: 'Sin libertad y en la pobreza, nadie puede salir de los límites de su distrito. Sólo una chica de 16 años, Katniss Everdeen, osa desafiar las normas para conseguir comida. Sus prinicipios se pondrán a prueba con “Los juegos del hambre”, espectáculo televisado que el Capitolio organiza para humillar a la población.',
-      pages: 560,
-    });
+      const [authorId] = authors[0].map(({ id }) => id);
+      return authorId;
+    }
 
-    return queryInterface.bulkInsert('books', booksArray);
+    let authorId = await findAuthorIdByLastName('Rowling');
+
+    if (authorId) {
+      booksArray.push({
+        title: 'Harry Potter y la piedra filosofal',
+        publication: 1997,
+        authorId,
+        description: 'Harry Potter se ha quedado huérfano y vive en casa de sus abominables tíos y el insoportable primo Dudley. Harry se siente muy triste y solo, hasta que un buen día recibe una carta que cambiará su vida para siempre. En ella le comunican que ha sido aceptado como alumno en el Colegio Hogwarts de Magia.',
+        pages: 800,
+      });
+
+      booksArray.push({
+        title: 'Harry Potter y la camara secreta',
+        publication: 1998,
+        authorId,
+        description: 'La trama sigue el segundo año de Harry Potter en el Colegio Hogwarts de Magia y Hechicería, durante el cual una serie de mensajes en las paredes de los pasillos de la escuela advierten que la Cámara de los Secretos ha sido abierta y que el "heredero de Slytherin" matará a todos los alumnos que no provengan de familias con sangre mágica.',
+        pages: 940,
+      });
+    }
+
+    authorId = await findAuthorIdByLastName('Collins');
+
+    if (authorId) {
+      booksArray.push({
+        title: 'Los juegos del hambre',
+        publication: 2008,
+        authorId,
+        description: 'Sin libertad y en la pobreza, nadie puede salir de los límites de su distrito. Sólo una chica de 16 años, Katniss Everdeen, osa desafiar las normas para conseguir comida. Sus prinicipios se pondrán a prueba con “Los juegos del hambre”, espectáculo televisado que el Capitolio organiza para humillar a la población.',
+        pages: 560,
+      });
+    }
+
+    return queryInterface.bulkInsert(
+      'books',
+      booksArray.map((book) => ({ ...book, ...commonData })),
+    );
   },
 
   down: async () => {


### PR DESCRIPTION
## What?
Se arreglaron las seeds de `books` para que su `authorId` no estuviese hardcoded.

## Why?
Tener un `authorId` hardcoded causaba que la ejecución de las seeds dependiera de qué id tuviese asignado el autor en particular. Para una persona podía tener un valor, mientras que para otra podía tener otro valor.

## How?
Se agregaron queries específicas para los autores, utilizando su `lastName` (proveniente de las seeds de `authors`). De esta manera se obtuvo su `authorId` asociado, y se entregó como parámetro para la creación de libros. Si por alguna razón el `lastName` específico no existe, entonces el libro no es agregado.

## Testing? (almost required)
No aplica.

## Screenshots (almost required in frontend)
No aplica.

## Anything Else? (optional)
No.
