### PR TITLE
feat(authors): add authors api endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "core-js": "^3.6.5",
     "dotenv": "^8.2.0",
     "faker": "^5.5.3",
+    "jsonapi-serializer": "^3.6.7",
     "koa": "^2.13.0",
     "koa-body": "^4.2.0",
     "koa-ejs": "^4.3.0",

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ const assets = require('./assets');
 const mailer = require('./mailers');
 const routes = require('./routes');
 const orm = require('./models');
+const api = require('./routes/api');
 
 // App constructor
 const app = new Koa();
@@ -22,7 +23,7 @@ app.keys = [
   'these secret keys are used to sign HTTP cookies',
   'to make sure only this app can generate a valid one',
   'and thus preventing someone just writing a cookie',
-  'saying he is logged in when it\'s really not',
+  "saying he is logged in when it's really not",
 ];
 
 // expose ORM through context's prototype
@@ -55,21 +56,31 @@ if (developmentMode) {
 app.use(koaStatic(path.join(__dirname, '..', 'build'), {}));
 
 // expose a session hash to store information across requests from same client
-app.use(session({
-  maxAge: 14 * 24 * 60 * 60 * 1000, // 2 weeks
-}, app));
+app.use(
+  session(
+    {
+      maxAge: 14 * 24 * 60 * 60 * 1000, // 2 weeks
+    },
+    app,
+  ),
+);
 
 // flash messages support
 app.use(koaFlashMessage);
 
 // parse request body
-app.use(koaBody({
-  multipart: true,
-  keepExtensions: true,
-}));
+app.use(
+  koaBody({
+    multipart: true,
+    keepExtensions: true,
+  }),
+);
 
 app.use((ctx, next) => {
-  ctx.request.method = override.call(ctx, ctx.request.body.fields || ctx.request.body);
+  ctx.request.method = override.call(
+    ctx,
+    ctx.request.body.fields || ctx.request.body,
+  );
   return next();
 });
 
@@ -85,5 +96,6 @@ mailer(app);
 
 // Routing middleware
 app.use(routes.routes());
+app.use(api.routes());
 
 module.exports = app;

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,7 +7,6 @@ const authors = require('./routes/authors');
 const books = require('./routes/books');
 const booksForAuthors = require('./routes/booksForAuthors');
 const session = require('./routes/session');
-const api = require('./routes/api');
 
 const router = new KoaRouter();
 
@@ -44,6 +43,5 @@ router.use('/authors', authors.routes());
 router.use('/books', books.routes());
 router.use('/authors/:authorId/books', booksForAuthors.routes());
 router.use('/session', session.routes());
-router.use('/api', api.routes());
 
 module.exports = router;

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,6 +7,7 @@ const authors = require('./routes/authors');
 const books = require('./routes/books');
 const booksForAuthors = require('./routes/booksForAuthors');
 const session = require('./routes/session');
+const api = require('./routes/api');
 
 const router = new KoaRouter();
 
@@ -43,5 +44,6 @@ router.use('/authors', authors.routes());
 router.use('/books', books.routes());
 router.use('/authors/:authorId/books', booksForAuthors.routes());
 router.use('/session', session.routes());
+router.use('/api', api.routes());
 
 module.exports = router;

--- a/src/routes/api/authors.js
+++ b/src/routes/api/authors.js
@@ -1,0 +1,5 @@
+const KoaRouter = require('koa-router');
+
+const router = new KoaRouter();
+
+module.exports = router;

--- a/src/routes/api/authors.js
+++ b/src/routes/api/authors.js
@@ -1,7 +1,7 @@
 const KoaRouter = require('koa-router');
-var JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 
-var AuthorSerializer = new JSONAPISerializer('authors', {
+const AuthorSerializer = new JSONAPISerializer('authors', {
   attributes: ['firstName', 'lastName', 'birthDate'],
   keyForAttribute: 'camelCase',
 });

--- a/src/routes/api/authors.js
+++ b/src/routes/api/authors.js
@@ -9,7 +9,7 @@ const AuthorSerializer = new JSONAPISerializer('authors', {
 const router = new KoaRouter();
 
 router.get('api.authors.show', '/:id', async (ctx) => {
-  const author = ctx.orm.author.findByPk(ctx.params.id);
+  const author = await ctx.orm.author.findByPk(ctx.params.id);
   if (!author) {
     ctx.throw(404, "The book you are looking for doesen't exists");
   }
@@ -18,7 +18,7 @@ router.get('api.authors.show', '/:id', async (ctx) => {
 
 router.post('api.authors.create', '/', async (ctx) => {
   try {
-    const author = await ctx.orm.author.build(ctx.request.body);
+    const author = ctx.orm.author.build(ctx.request.body);
     await author.save({ fields: ['lastName', 'firstName', 'birthDate'] });
     ctx.status = 201;
     ctx.body = AuthorSerializer.serialize(author);

--- a/src/routes/api/authors.js
+++ b/src/routes/api/authors.js
@@ -9,7 +9,7 @@ const AuthorSerializer = new JSONAPISerializer('authors', {
 const router = new KoaRouter();
 
 router.get('api.authors.show', '/:id', async (ctx) => {
-  const author = await ctx.orm.author.findByPk(ctx.params.id);
+  const author = ctx.orm.author.findByPk(ctx.params.id);
   if (!author) {
     ctx.throw(404, "The book you are looking for doesen't exists");
   }

--- a/src/routes/api/authors.js
+++ b/src/routes/api/authors.js
@@ -11,7 +11,7 @@ const router = new KoaRouter();
 router.get('api.authors.show', '/:id', async (ctx) => {
   const author = await ctx.orm.author.findByPk(ctx.params.id);
   if (!author) {
-    ctx.throw(404, "The book you are looking for doesen't exists");
+    ctx.throw(404, "The author you are looking for doesn't exist");
   }
   ctx.body = AuthorSerializer.serialize(author);
 });

--- a/src/routes/api/authors.js
+++ b/src/routes/api/authors.js
@@ -19,7 +19,7 @@ router.get('api.authors.show', '/:id', async (ctx) => {
 router.post('api.authors.create', '/', async (ctx) => {
   try {
     const author = ctx.orm.author.build(ctx.request.body);
-    await author.save({ fields: ['lastName', 'firstName', 'birthDate'] });
+    await author.save({ fields: ['firstName', 'lastName', 'birthDate'] });
     ctx.status = 201;
     ctx.body = AuthorSerializer.serialize(author);
   } catch (ValidationError) {

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -1,0 +1,8 @@
+const KoaRouter = require('koa-router');
+const authors = require('./authors');
+
+const router = new KoaRouter();
+
+router.use('/authors', authors.routes());
+
+module.exports = router;

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -1,7 +1,7 @@
 const KoaRouter = require('koa-router');
 const authors = require('./authors');
 
-const router = new KoaRouter();
+const router = new KoaRouter({ prefix: '/api' });
 
 router.use('/authors', authors.routes());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4573,6 +4573,11 @@ inflation@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/inflation/-/inflation-2.0.0.tgz"
 
+inflected@^1.1.6:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/inflected/-/inflected-1.1.7.tgz#c393df6e28472d0d77b3082ec3aa2091f4bc96f9"
+  integrity sha1-w5PfbihHLQ13swguw6ogkfS8lvk=
+
 inflection@1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz"
@@ -5539,6 +5544,14 @@ json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+jsonapi-serializer@^3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/jsonapi-serializer/-/jsonapi-serializer-3.6.7.tgz#18299122e7624d962fadaba16c320da6a7c405c0"
+  integrity sha512-usScb34T6mB0QK/AxOpXTpE9iB7JW4/CMhREitzeKv9rV5CdZhdVA8F9zIc7Xz9rjbSv98vOXkuO1HRtM0paSg==
+  dependencies:
+    inflected "^1.1.6"
+    lodash "^4.16.3"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz"
@@ -5864,6 +5877,11 @@ lodash.sortby@^4.7.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.16.3:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What?
Se implementaron dos enpoints para manejar el recurso _authors_

## Why?

Para poder proveer parte de la aplicación como una API.

El _body_ del _response_ en cada caso sigue el estándar [jsonapi](https://jsonapi.org/):
```json
{
    "data": {
        "type": "authors",
        "id": "1",
        "attributes": {
            "firstName": "Joanne",
            "lastName": "Rowling",
            "birthDate": "1965-07-31"
        }
    }
}
```

## How?

Utilizando `koa-router` se creó un _router_ con un método `GET` y otro `POST` y se usó `jsonapi-serializer` para serializar el _response_ de los requests.

## Anything Else? (optional)
Para probarlo es importante correr:
```bash
yarn install
```
