### PR TITLE
fix: added non-null fields constraints to authors

### DIFF
--- a/src/migrations/20210608053733-change-allowNull-models.js
+++ b/src/migrations/20210608053733-change-allowNull-models.js
@@ -1,0 +1,14 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => [
+    await queryInterface.changeColumn('authors', 'firstName', {
+      allowNull: false,
+      type: Sequelize.STRING,
+    }),
+  ],
+
+  down: async (queryInterface, Sequelize) => [
+    await queryInterface.changeColumn('authors', 'firstName', {
+      type: Sequelize.STRING,
+    }),
+  ],
+};

--- a/src/models/author.js
+++ b/src/models/author.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
     {
       firstName: {
         type: DataTypes.STRING,
+        allowNull: false,
         validate: {
           notEmpty: true,
         },

--- a/src/models/book.js
+++ b/src/models/book.js
@@ -29,12 +29,14 @@ module.exports = (sequelize, DataTypes) => {
       authorId: DataTypes.INTEGER,
       description: {
         type: DataTypes.STRING,
+        allowNull: false,
         validate: {
           notEmpty: true,
         },
       },
       pages: {
         type: DataTypes.INTEGER,
+        allowNull: false,
         validate: {
           notEmpty: true,
         },


### PR DESCRIPTION
## What?
Se agrego el campo `allowNull: false` para el modelo _author_, incluyendo su respectiva migración.

## Why?
Para evitar que se pudiera crear un autor sin nombre; debido a esto, algunos _tests_ que quería mostrar en la cápsula _Endpoint tests_ estaban fallando.

## How?
Se creó una migración que agrega este cambio en la columna de la tabla _authors_.

## Testing? (almost required)
Se probo hacer un _request_ desde _Talend API Tester_ para verificar la creación de un autor sin nombre, este no se creaba.

## Anything Else? (optional)
- Se agregó lo mismo al modelo de libros. Las migraciones ya existían, pero faltaba la validación mediante el modelo.
