### PR TITLE
Feat/koa cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webpack-manifest-plugin": "^2.2.0"
   },
   "dependencies": {
+    "@koa/cors": "^3.1.0",
     "bcrypt": "^5.0.1",
     "cloudinary": "^1.26.0",
     "core-js": "^3.6.5",

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const path = require('path');
 const Koa = require('koa');
 const koaBody = require('koa-body');
@@ -6,6 +7,7 @@ const koaFlashMessage = require('koa-flash-message').default;
 const koaStatic = require('koa-static');
 const render = require('koa-ejs');
 const session = require('koa-session');
+const cors = require('@koa/cors');
 const override = require('koa-override-method');
 const cloudinary = require('cloudinary').v2;
 const assets = require('./assets');
@@ -16,6 +18,9 @@ const api = require('./routes/api');
 
 // App constructor
 const app = new Koa();
+
+// CORS
+app.use(cors({ origin: process.env.ORIGIN || 'http://localhost:8000' }));
 
 const developmentMode = app.env === 'development';
 const testMode = app.env === 'test';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,6 +1199,13 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@koa/cors@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.1.0.tgz#618bb073438cfdbd3ebd0e648a76e33b84f3a3b2"
+  integrity sha512-7ulRC1da/rBa6kj6P4g2aJfnET3z8Uf3SWu60cjbtxTA5g8lxRdX/Bd2P92EagGwwAhANeNw8T8if99rJliR6Q==
+  dependencies:
+    vary "^1.1.2"
+
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"


### PR DESCRIPTION
## What?
Se añade el middleware para permitir CORS desde un origen específico.

## Why?
Para poder hacer llamados a la API desde la aplicación de frontend

## How?
Se usó el paquete  ```@koa/cors```, especificando en sus options un origin, que puede venir de una variable de entorno ```ORIGIN```, si no existe toma por defecto ```https://localhost:8000```

## Testing? (almost required)
Se probó manualmente haciendo requests desde la ruta ```https://localhost:8000```

## Anything Else? (optional)
Salu2
