### PR TITLE
api post user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Gud Reads
+[![IIC2513 Node CI](https://github.com/IIC2513-2021-1/GudReads/actions/workflows/iic2513-node.yml/badge.svg)](https://github.com/IIC2513-2021-1/GudReads/actions/workflows/iic2513-node.yml)
+
 Código de ejemplo en el contexto de las cápsulas desarrolladas para demostrar usos básicos del template del curso.
 
 ## Usuario de prueba para login:

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -9,6 +9,7 @@ const router = new KoaRouter({ prefix: '/api' });
 
 /* Unprotected routes */
 router.use('/auth', auth.routes());
+router.use('/users', users.routes());
 
 /* Protected routes */
 router.use(jwt({ secret: process.env.JWT_SECRET, key: 'authData' }).unless({ method: 'GET' }));

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -4,6 +4,7 @@ const jwt = require('koa-jwt');
 const { apiSetCurrentUser } = require('../../middlewares/auth');
 const authors = require('./authors');
 const auth = require('./auth');
+const users = require('./users');
 
 const router = new KoaRouter({ prefix: '/api' });
 

--- a/src/routes/api/users.js
+++ b/src/routes/api/users.js
@@ -1,0 +1,22 @@
+const KoaRouter = require('koa-router');
+const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+
+const UserSerializer = new JSONAPISerializer('users', {
+  attributes: ['firstName', 'lastName', 'email', 'password'],
+  keyForAttribute: 'camelCase',
+});
+
+const router = new KoaRouter();
+
+router.post('api.users.create', '/', async (ctx) => {
+  try {
+    const user = ctx.orm.user.build(ctx.request.body);
+    await user.save({ fields: ['firstName', 'lastName', 'email', 'password'] });
+    ctx.status = 201;
+    ctx.body = UserSerializer.serialize(user);
+  } catch (ValidationError) {
+    ctx.throw(400, 'Bad request');
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## What?
Se crea la ruta `api/users` de tipo POST, en donde crea un usuario según los atributos entregados, se comprueba que no hayan errores de crlf

## Why?
Este endpoint se crea porque era necesario que en la cápsula 33 la aplicación de frontend llamara a la API para implementar un formulario de registro de usuario

## How?
Se reciben datos a partir del body, si se puede crear un modelo de tipo `user`, la aplicación arroja un status 200 y el usuario serializado, de lo contrario un error 400

## Testing? (almost required)
No se realizó testeo

## Screenshots (almost required in frontend)
La aplicación no cambia visualmente